### PR TITLE
#11: extends tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 dist
+coverage

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "serve": "vue-cli-service serve",
     "build": "vue-cli-service build",
     "test:unit": "vue-cli-service test:unit --setupTestFrameworkScriptFile=./tests/setup.js",
+    "test:coverage": "vue-cli-service test:unit --coverage=true --setupTestFrameworkScriptFile=./tests/setup.js",
     "test:local": "vue-cli-service test:unit --watch --setupTestFrameworkScriptFile=./tests/setup.js",
     "lint": "vue-cli-service lint",
     "gh-pages-deploy": "node scripts/gh-pages-deploy.js"

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "serve": "vue-cli-service serve",
     "build": "vue-cli-service build",
     "test:unit": "vue-cli-service test:unit --setupTestFrameworkScriptFile=./tests/setup.js",
+    "test:local": "vue-cli-service test:unit --watch --setupTestFrameworkScriptFile=./tests/setup.js",
     "lint": "vue-cli-service lint",
     "gh-pages-deploy": "node scripts/gh-pages-deploy.js"
   },

--- a/src/components/transaction/transaction-dialog.vue
+++ b/src/components/transaction/transaction-dialog.vue
@@ -1,12 +1,12 @@
 <template>
-  <v-dialog v-model="visible" persistent max-width="500px" @keydown.esc="close">
+  <v-dialog id="dialog-transaction" v-model="visible" persistent max-width="500px" @keydown.esc="close">
     <v-card>
       <v-card-title>
-        <span class="headline">{{ formTitle }}</span>
+        <span id="dialog-transaction-title" class="headline">{{ formTitle }}</span>
       </v-card-title>
       <v-card-text>
         <v-container>
-          <v-text-field v-model="item.payee" label="Payee" :rules="[rules.required]"></v-text-field>
+          <v-text-field id="text-payee" v-model="item.payee" label="Payee" :rules="[rules.required]"></v-text-field>
           <v-text-field v-model="item.category" label="Category" :rules="[rules.required]"></v-text-field>
           <v-text-field v-model="item.date" label="Date" type="date" :rules="[rules.required]"></v-text-field>
           <v-text-field v-model="item.memo" label="Memo"></v-text-field>
@@ -22,8 +22,10 @@
       </v-card-text>
       <v-card-actions>
         <v-spacer></v-spacer>
-        <v-btn text @click="close">Cancel</v-btn>
-        <v-btn color="accent" :disabled="submitDisabled" text @click="save">{{ submitBtn }}</v-btn>
+        <v-btn id="btn-transaction-dialog-close" text @click="close">Cancel</v-btn>
+        <v-btn id="btn-transaction-dialog-submit" color="accent" :disabled="submitDisabled" text @click="save">
+          {{ submitBtn }}
+        </v-btn>
       </v-card-actions>
     </v-card>
   </v-dialog>

--- a/src/components/transaction/transaction-table.vue
+++ b/src/components/transaction/transaction-table.vue
@@ -4,7 +4,7 @@
     <template v-slot:top>
       <v-toolbar flat color="white">
         <v-spacer></v-spacer>
-        <v-btn color="accent" dark class="mb-2" @click="newTransaction()">New Transaction</v-btn>
+        <v-btn id="btn-create-transaction" color="accent" dark class="mb-2" @click="newTransaction()">New Transaction</v-btn>
         <TransactionDialog :is-visible="showDialog" :item="dialogItem" @dialog-closed="showDialog = $event" />
       </v-toolbar>
     </template>
@@ -53,7 +53,7 @@ export default {
     },
 
     getAmountColor(outflow) {
-      return outflow ? 'red--text' : 'green--text';
+      return 'amount-cell ' + (outflow ? 'red--text' : 'green--text');
     },
 
     getAmount(amount) {

--- a/src/store/store.js
+++ b/src/store/store.js
@@ -6,6 +6,13 @@ import { TRANSACTION_CREATE } from './mutation-types';
 
 Vue.use(Vuex);
 
+export const mutations = {
+  [TRANSACTION_CREATE](state, transaction) {
+    transaction.id = generateRandomNo();
+    state.transactions.push(transaction);
+  },
+};
+
 export default new Vuex.Store({
   state: {
     transactions: [
@@ -14,12 +21,7 @@ export default new Vuex.Store({
       new Transaction(generateRandomNo(), 'ADH', 'Beer', Date(), 'Insurance', 9.99, true),
     ],
   },
-  mutations: {
-    [TRANSACTION_CREATE](state, transaction) {
-      transaction.id = generateRandomNo();
-      state.transactions.push(transaction);
-    },
-  },
+  mutations: mutations,
   actions: {},
   modules: {},
 });

--- a/tests/unit/components/navigation.spec.js
+++ b/tests/unit/components/navigation.spec.js
@@ -2,22 +2,22 @@ import { mount, createLocalVue } from '@vue/test-utils';
 import Navigation from '@/components/navigation.vue';
 import Vuetify from 'vuetify';
 
-const localVue = createLocalVue();
-
 describe('navigation.vue', () => {
+  let localVue;
   let vuetify;
+  let wrapper;
 
   beforeEach(() => {
+    localVue = createLocalVue();
     vuetify = new Vuetify();
-  });
-
-  it('contains 3 items', () => {
-    const wrapper = mount(Navigation, {
+    wrapper = mount(Navigation, {
       localVue,
       vuetify,
       propsData: { drawer: false },
     });
+  });
 
+  it('contains 3 items', () => {
     expect(wrapper.find('#btn-expenses').exists()).toBe(true);
     expect(wrapper.find('#btn-settings').exists()).toBe(true);
     expect(wrapper.find('#btn-about').exists()).toBe(true);

--- a/tests/unit/components/navigation.spec.js
+++ b/tests/unit/components/navigation.spec.js
@@ -13,13 +13,27 @@ describe('navigation.vue', () => {
     wrapper = mount(Navigation, {
       localVue,
       vuetify,
-      propsData: { drawer: false },
+      propsData: { shouldShowDrawer: false },
     });
   });
 
-  it('contains 3 items', () => {
-    expect(wrapper.find('#btn-expenses').exists()).toBe(true);
-    expect(wrapper.find('#btn-settings').exists()).toBe(true);
-    expect(wrapper.find('#btn-about').exists()).toBe(true);
+  it('shows drawer based on property', async () => {
+    await wrapper.setProps({ shouldShowDrawer: true });
+    const visibleStyle = wrapper.attributes('style');
+
+    await wrapper.setProps({ shouldShowDrawer: false });
+    const invisibleStyle = wrapper.attributes('style');
+    expect(visibleStyle).not.toBe(invisibleStyle);
+  });
+
+  it('contains 3 menu items', () => {
+    const expensesBtn = wrapper.find('#btn-expenses');
+    expect(expensesBtn.text()).toBe('Transactions');
+
+    const settingsBtn = wrapper.find('#btn-settings');
+    expect(settingsBtn.text()).toBe('Settings');
+
+    const aboutBtn = wrapper.find('#btn-about');
+    expect(aboutBtn.text()).toBe('About');
   });
 });

--- a/tests/unit/components/transaction/transaction-dialog.spec.js
+++ b/tests/unit/components/transaction/transaction-dialog.spec.js
@@ -1,0 +1,64 @@
+import { mount, createLocalVue } from '@vue/test-utils';
+import Vuetify from 'vuetify';
+import TransactionDialog from '@/components/transaction/transaction-dialog.vue';
+import Transaction from '@/components/transaction/transaction';
+import { TRANSACTION_CREATE } from '@/store/mutation-types';
+
+const transaction = new Transaction('someId', 'somePayee', 'someMemo', '2019-02-02', 'someCategory', 13.37, true);
+
+describe('transaction-dialog.vue', () => {
+  let localVue;
+  let vuetify;
+  let wrapper;
+
+  beforeEach(() => {
+    localVue = createLocalVue();
+    vuetify = new Vuetify();
+    wrapper = mount(TransactionDialog, {
+      localVue,
+      vuetify,
+      data: () => ({ visible: true }),
+      propsData: { item: transaction },
+    });
+  });
+
+  it('renders based on the "isVisible" property', async () => {
+    const testWrapper = mount(TransactionDialog, {
+      localVue,
+      vuetify,
+      propsData: { item: transaction },
+    });
+
+    await testWrapper.setProps({ isVisible: false });
+    expect(testWrapper.find('#dialog-transaction').text()).toBe('');
+
+    await testWrapper.setProps({ isVisible: true });
+    expect(testWrapper.find('#dialog-transaction').text()).not.toBe('');
+  });
+
+  it('renders create dialog', () => {
+    const createWrapper = mount(TransactionDialog, {
+      localVue,
+      vuetify,
+      data: () => ({ visible: true }),
+      propsData: { item: {} },
+    });
+
+    expect(createWrapper.find('#dialog-transaction-title').text()).toBe('New Transaction');
+    expect(createWrapper.find('#btn-transaction-dialog-submit').text()).toBe('Create');
+  });
+
+  it('renders edit dialog', () => {
+    expect(wrapper.find('#dialog-transaction-title').text()).toBe('Edit Transaction');
+    expect(wrapper.find('#btn-transaction-dialog-submit').text()).toBe('Update');
+  });
+
+  it('emits close event if close button is clicked', async () => {
+    const closeBtn = wrapper.find('#btn-transaction-dialog-close');
+    await closeBtn.trigger('click');
+
+    // One 'dialog-closed' with value 'false' should've been emitted
+    expect(wrapper.emitted()['dialog-closed'].length).toBe(1);
+    expect(wrapper.emitted()['dialog-closed'][0]).toEqual([false]);
+  });
+});

--- a/tests/unit/components/transaction/transaction-dialog.spec.js
+++ b/tests/unit/components/transaction/transaction-dialog.spec.js
@@ -2,63 +2,54 @@ import { mount, createLocalVue } from '@vue/test-utils';
 import Vuetify from 'vuetify';
 import TransactionDialog from '@/components/transaction/transaction-dialog.vue';
 import Transaction from '@/components/transaction/transaction';
-import { TRANSACTION_CREATE } from '@/store/mutation-types';
-
-const transaction = new Transaction('someId', 'somePayee', 'someMemo', '2019-02-02', 'someCategory', 13.37, true);
 
 describe('transaction-dialog.vue', () => {
-  let localVue;
-  let vuetify;
-  let wrapper;
-
-  beforeEach(() => {
-    localVue = createLocalVue();
-    vuetify = new Vuetify();
-    wrapper = mount(TransactionDialog, {
-      localVue,
-      vuetify,
-      data: () => ({ visible: true }),
-      propsData: { item: transaction },
-    });
-  });
+  const transaction = new Transaction('someId', 'somePayee', 'someMemo', '2019-02-02', 'someCategory', 13.37, true);
+  const localVue = createLocalVue();
+  const vuetify = new Vuetify();
 
   it('renders based on the "isVisible" property', async () => {
-    const testWrapper = mount(TransactionDialog, {
-      localVue,
-      vuetify,
-      propsData: { item: transaction },
-    });
+    const dialog = mountDialog(transaction, false);
 
-    await testWrapper.setProps({ isVisible: false });
-    expect(testWrapper.find('#dialog-transaction').text()).toBe('');
+    await dialog.setProps({ isVisible: false });
+    expect(dialog.find('#dialog-transaction').text()).toBe('');
 
-    await testWrapper.setProps({ isVisible: true });
-    expect(testWrapper.find('#dialog-transaction').text()).not.toBe('');
+    await dialog.setProps({ isVisible: true });
+    expect(dialog.find('#dialog-transaction').text()).not.toBe('');
   });
 
   it('renders create dialog', () => {
-    const createWrapper = mount(TransactionDialog, {
-      localVue,
-      vuetify,
-      data: () => ({ visible: true }),
-      propsData: { item: {} },
-    });
+    const dialog = mountDialog({}, true);
 
-    expect(createWrapper.find('#dialog-transaction-title').text()).toBe('New Transaction');
-    expect(createWrapper.find('#btn-transaction-dialog-submit').text()).toBe('Create');
+    expect(dialog.find('#dialog-transaction-title').text()).toBe('New Transaction');
+    expect(dialog.find('#btn-transaction-dialog-submit').text()).toBe('Create');
   });
 
   it('renders edit dialog', () => {
-    expect(wrapper.find('#dialog-transaction-title').text()).toBe('Edit Transaction');
-    expect(wrapper.find('#btn-transaction-dialog-submit').text()).toBe('Update');
+    const dialog = mountDialog(transaction, true);
+
+    expect(dialog.find('#dialog-transaction-title').text()).toBe('Edit Transaction');
+    expect(dialog.find('#btn-transaction-dialog-submit').text()).toBe('Update');
   });
 
   it('emits close event if close button is clicked', async () => {
-    const closeBtn = wrapper.find('#btn-transaction-dialog-close');
+    const dialog = mountDialog(transaction, true);
+
+    const closeBtn = dialog.find('#btn-transaction-dialog-close');
     await closeBtn.trigger('click');
 
     // One 'dialog-closed' with value 'false' should've been emitted
-    expect(wrapper.emitted()['dialog-closed'].length).toBe(1);
-    expect(wrapper.emitted()['dialog-closed'][0]).toEqual([false]);
+    expect(dialog.emitted()['dialog-closed'].length).toBe(1);
+    expect(dialog.emitted()['dialog-closed'][0]).toEqual([false]);
   });
+
+  function mountDialog(transaction, shouldRender) {
+    // document.body.setAttribute('data-app', true);
+    return mount(TransactionDialog, {
+      localVue,
+      vuetify,
+      data: () => (shouldRender ? { visible: true } : {}),
+      propsData: { item: transaction },
+    });
+  }
 });

--- a/tests/unit/components/transaction/transaction-table.spec.js
+++ b/tests/unit/components/transaction/transaction-table.spec.js
@@ -1,0 +1,57 @@
+import { mount, createLocalVue } from '@vue/test-utils';
+import Vuetify from 'vuetify';
+import TransactionTable from '@/components/transaction/transaction-table.vue';
+import Vuex from 'vuex';
+import Transaction from '../../../../src/components/transaction/transaction';
+
+describe('transaction-table.vue', () => {
+  const localVue = createLocalVue();
+  localVue.use(Vuex);
+  const vuetify = new Vuetify();
+
+  const store = new Vuex.Store({
+    state: {
+      transactions: [
+        new Transaction('id1', 'Rewe', 'Nachos', Date(), 'Groceries', 2.99, true),
+        new Transaction('id2', 'cc', 'Income', Date(), 'Groceries', 13.99, false),
+      ],
+    },
+  });
+
+  const table = mount(TransactionTable, { localVue, vuetify, store });
+
+  it('renders column headers correctly', () => {
+    let columnHeaders = table.findAll('.v-data-table-header th');
+
+    expect(columnHeaders.length).toEqual(6);
+    expect(columnHeaders.at(0).text()).toEqual('Payee');
+    expect(columnHeaders.at(1).text()).toEqual('Memo');
+    expect(columnHeaders.at(2).text()).toEqual('Date');
+    expect(columnHeaders.at(3).text()).toEqual('Category');
+    expect(columnHeaders.at(4).text()).toEqual('Amount');
+    expect(columnHeaders.at(5).text()).toEqual('Actions');
+  });
+
+  it('renders create button in table toolbar', () => {
+    let createBtn = table.find('.v-toolbar #btn-create-transaction');
+
+    expect(createBtn.text()).toEqual('New Transaction');
+  });
+
+  it('renders transaction rows correctly', () => {
+    let bodyRows = table.findAll('tbody > tr');
+
+    expect(bodyRows.length).toEqual(2);
+    expect(bodyRows.at(0).text()).toContain('Rewe');
+    expect(bodyRows.at(1).text()).toContain('cc');
+  });
+
+  it('renders outflow cell in colors', () => {
+    let amountCells = table.findAll('tbody td > .amount-cell');
+    let outflowCell = amountCells.at(0);
+    let inflowCell = amountCells.at(1);
+
+    expect(outflowCell.classes('red--text')).toBeTruthy();
+    expect(inflowCell.classes('green--text')).toBeTruthy();
+  });
+});

--- a/tests/unit/components/transaction/transaction-table.spec.js
+++ b/tests/unit/components/transaction/transaction-table.spec.js
@@ -1,4 +1,4 @@
-import { mount, createLocalVue } from '@vue/test-utils';
+import { mount, createLocalVue, createWrapper } from '@vue/test-utils';
 import Vuetify from 'vuetify';
 import TransactionTable from '@/components/transaction/transaction-table.vue';
 import Vuex from 'vuex';
@@ -53,5 +53,18 @@ describe('transaction-table.vue', () => {
 
     expect(outflowCell.classes('red--text')).toBeTruthy();
     expect(inflowCell.classes('green--text')).toBeTruthy();
+  });
+
+  it('opens edit dialog with row item data', async () => {
+    // Dialog is not rendered by default
+    const editDialog = table.find('#dialog-transaction');
+    expect(editDialog.text()).toBe('');
+
+    const firstItemEditBtn = table.findAll('.mdi-pencil').at(0);
+    await firstItemEditBtn.trigger('click');
+
+    // Edit button opens dialog and passes item data
+    expect(editDialog.text()).not.toBe('');
+    expect(editDialog.props('item').payee).toBe(store.state.transactions[0].payee);
   });
 });

--- a/tests/unit/store/store.spec.js
+++ b/tests/unit/store/store.spec.js
@@ -1,0 +1,18 @@
+import { mutations } from '@/store/Store.js';
+import { defaultTransaction } from '@/components/transaction/transaction';
+import { TRANSACTION_CREATE } from '@/store/mutation-types';
+
+describe('mutations', () => {
+  it('TRANSACTION_CREATE', () => {
+    const state = { transactions: [] };
+
+    const newTransaction = defaultTransaction();
+    expect(newTransaction.id).toBeNull();
+
+    mutations[TRANSACTION_CREATE](state, newTransaction);
+
+    expect(newTransaction.id).not.toBeNull();
+    expect(state.transactions.length).toBe(1);
+    expect(state.transactions[0]).toEqual(newTransaction);
+  });
+});

--- a/tests/unit/store/store.spec.js
+++ b/tests/unit/store/store.spec.js
@@ -1,4 +1,4 @@
-import { mutations } from '@/store/Store.js';
+import { mutations } from '@/store/store.js';
 import { defaultTransaction } from '@/components/transaction/transaction';
 import { TRANSACTION_CREATE } from '@/store/mutation-types';
 


### PR DESCRIPTION
Changes in this PR:
- extend the unit tests for the all existing components
- adds the `test:coverage` npm script, that executes the unit tests once and caluclates the code coverage
- adds the `test:local` npm script, that executes the unit tests in the interactive mode

I couldn't find a solution for the `[Vuetify] Unable to locate target [data-app]` warnings, that are currently shown in all tests that include a dialog. The [solutions I could find](https://forum.vuejs.org/t/vuetify-data-app-true-and-problems-rendering-v-dialog-in-unit-tests/27495) did remove the warnings - but also did break some tests.